### PR TITLE
Add repositories to templates sync

### DIFF
--- a/sync.yml
+++ b/sync.yml
@@ -1,3 +1,5 @@
+# Configuration for repository issue template syncing
+# ref: https://github.com/BetaHuhn/repo-file-sync-action
 group:
   # Private repositories require a markdown file
   - repos: |
@@ -8,5 +10,6 @@ group:
   - repos: |
       2i2c-org/infrastructure
       2i2c-org/team-compass
+      2i2c-org/pilot
     files: 
       - .github/ISSUE_TEMPLATE/01_new-issue.yml

--- a/workflows/sync-issue-templates.yaml
+++ b/workflows/sync-issue-templates.yaml
@@ -1,4 +1,4 @@
-name: Sync Issue Templates
+name: "Sync Issue Templates"
 on:
   push:
     branches:


### PR DESCRIPTION
Adds a few extra repositories to our issue template sync. I accidentally commited the first change directly to `main` (sorry!)

The original commit was adding the use of [this file sync action](https://github.com/BetaHuhn/repo-file-sync-action) to the repository. Here is a short summary:

- It uses a personal access token that I created with write permissions to 2i2c repositories
- Upon commit to main, it will check for changes in the files defined in `sync.yml`
- If a file is changed, it will make a PR to update that file in the target repository (defined in groups in `sync.yml`

This should let us define our issue templates in a single place so we don't have to keep updating them throughout

gonna merge this in so that I can test this out. 