### PR TITLE
Update issue templates into 3 sections

### DIFF
--- a/.github/ISSUE_TEMPLATE/01_new-issue.md
+++ b/.github/ISSUE_TEMPLATE/01_new-issue.md
@@ -9,11 +9,11 @@ about: A general template for many kinds of issues.
 
 ### Proposal
 
-<!-- (optional) A clear and concise description of what we should do, if we have a next step in mind. -->
+<!--
+(optional) A clear and concise description of what we should do, if we have a next step in mind.
 
-### Implementation guide
-
-<!-- (optional) Anything that will lower our uncertainty in resolving this, if we have instructions, constraints to follow, red flags to avoid, etc. -->
+Add any guidance that will lower our uncertainty in resolving this (e.g., instructions, constraints to follow, red flags to avoid).
+-->
 
 ### Updates and actions
 

--- a/.github/ISSUE_TEMPLATE/01_new-issue.md
+++ b/.github/ISSUE_TEMPLATE/01_new-issue.md
@@ -5,27 +5,16 @@ about: A general template for many kinds of issues.
 
 ### Context
 
-Background information: When ___ kind of person is trying to do ___, then ___ happens.
-Problem or opportunity:  This is a problem because ___. It would be better if ___.
+<!-- Any background information that helps others take understand this issue and why it is important. -->
 
 ### Proposal
 
-Action to take: We should make it possible to ___ by doing ___.
-Value and who benefits: This would allow ___ users to ___.
+<!-- (optional) A clear and concise description of what we should do, if we have a next step in mind. -->
 
 ### Implementation guide
 
-<!-- Anything that will help lower the uncertainty in doing this. -->
-
-- The best way to do this would be...
-- This work should *not* include...
-- We should try to do ___ in a 2-week time box before moving further.
+<!-- (optional) Anything that will lower our uncertainty in resolving this, if we have instructions, constraints to follow, red flags to avoid, etc. -->
 
 ### Updates and actions
 
-<!--
-Provide updates as we start to plan and do work.
-- Sub-issues and tasks to work on
-- Links to project boards
-- Updates over time
--->
+<!-- (optional) A place to track ongoing work items or tasks, as we figure them out. -->

--- a/.github/ISSUE_TEMPLATE/01_new-issue.md
+++ b/.github/ISSUE_TEMPLATE/01_new-issue.md
@@ -3,17 +3,17 @@ name: "💡 General Issue"
 about: A general template for many kinds of issues.
 ---
 
-### Background and proposal
+### Context
 
-**Context**
 Background information: When ___ kind of person is trying to do ___, then ___ happens.
 Problem or opportunity:  This is a problem because ___. It would be better if ___.
 
-**Proposed solution**
+### Proposal
+
 Action to take: We should make it possible to ___ by doing ___.
 Value and who benefits: This would allow ___ users to ___.
 
-### Implementation guide and constraints
+### Implementation guide
 
 <!-- Anything that will help lower the uncertainty in doing this. -->
 
@@ -21,7 +21,7 @@ Value and who benefits: This would allow ___ users to ___.
 - This work should *not* include...
 - We should try to do ___ in a 2-week time box before moving further.
 
-### Updates and ongoing work
+### Updates and actions
 
 <!--
 Provide updates as we start to plan and do work.

--- a/.github/ISSUE_TEMPLATE/01_new-issue.yml
+++ b/.github/ISSUE_TEMPLATE/01_new-issue.yml
@@ -2,34 +2,42 @@ name: 💡 General Issue
 description: A general template for many kinds of issues.
 body:
   - type: textarea
-    id: description
+    id: context
     attributes:
-      label: Background and proposal
+      label: Context
       description: |
+        Any background information that helps others take understand this issue.
+
         - **What is the problem** that needs to be solved?
         - **What is the solution** that would resolve it?
         - **What is the opportunity / value** in solving this problem? And for who?
-
-        _below is a suggested structure_
       value: |
-        **Context**
-        Background information: When ___ kind of person is trying to do ___, then ___ happens.
-        Problem or opportunity:  This is a problem because ___. It would be better if ___.
-
-        **Proposed solution**
-        Action to take: We should make it possible to ___ by doing ___.
-        Value and who benefits: This would allow ___ users to ___.
-
+        When ___ kind of person is trying to do ___, then ___ happens.
+        This is a problem because ___. It would be better if ___.
     validations:
       required: true
 
   - type: textarea
+    id: proposal
+    attributes:
+      label: Proposal
+      description: |
+        A clear and concise description of what we should do.
+      value: |
+        We should make it possible to ___ by doing ___.
+        This would allow ___ users to ___.
+
+    validations:
+      required: true
+
+
+  - type: textarea
     id: implementation
     attributes:
-      label: Implementation guide and constraints
+      label: Implementation guide
       description: |
 
-        _Anything that will help lower the uncertainty in doing this._
+        Anything that will help lower the uncertainty in doing this.
 
         - Suggestions to reduce risk and guide others who may want to implement a solution.
         - Constraints and "out of scope" ideas that shouldn't be addressed here.
@@ -45,7 +53,7 @@ body:
   - type: textarea
     id: tasks
     attributes:
-      label: Updates and ongoing work
+      label: Updates and actions
       description: |
         Provide updates as we start to plan and do work.
         - Sub-issues and tasks to work on

--- a/.github/ISSUE_TEMPLATE/01_new-issue.yml
+++ b/.github/ISSUE_TEMPLATE/01_new-issue.yml
@@ -16,18 +16,7 @@ body:
       label: Proposal
       description: |
         (optional) A clear and concise description of what we should do, if we have a next step in mind.
-
-    validations:
-      required: false
-
-
-  - type: textarea
-    id: implementation
-    attributes:
-      label: Implementation guide
-      description: |
-        (optional) Anything that will lower our uncertainty in resolving this, if we have instructions, constraints to follow, red flags to avoid, etc.
-
+        Add any guidance that will lower our uncertainty in resolving this (e.g., instructions, constraints to follow, red flags to avoid).
     validations:
       required: false
 

--- a/.github/ISSUE_TEMPLATE/01_new-issue.yml
+++ b/.github/ISSUE_TEMPLATE/01_new-issue.yml
@@ -6,14 +6,7 @@ body:
     attributes:
       label: Context
       description: |
-        Any background information that helps others take understand this issue.
-
-        - **What is the problem** that needs to be solved?
-        - **What is the solution** that would resolve it?
-        - **What is the opportunity / value** in solving this problem? And for who?
-      value: |
-        When ___ kind of person is trying to do ___, then ___ happens.
-        This is a problem because ___. It would be better if ___.
+        Any background information that helps others take understand this issue and why it is important.
     validations:
       required: true
 
@@ -22,13 +15,10 @@ body:
     attributes:
       label: Proposal
       description: |
-        A clear and concise description of what we should do.
-      value: |
-        We should make it possible to ___ by doing ___.
-        This would allow ___ users to ___.
+        (optional) A clear and concise description of what we should do, if we have a next step in mind.
 
     validations:
-      required: true
+      required: false
 
 
   - type: textarea
@@ -36,16 +26,7 @@ body:
     attributes:
       label: Implementation guide
       description: |
-
-        Anything that will help lower the uncertainty in doing this.
-
-        - Suggestions to reduce risk and guide others who may want to implement a solution.
-        - Constraints and "out of scope" ideas that shouldn't be addressed here.
-        - Time boxes and work planning.
-      placeholder: |
-        - The best way to do this would be...
-        - This work should *not* include...
-        - We should try to do ___ in a 2-week time box before moving further.
+        (optional) Anything that will lower our uncertainty in resolving this, if we have instructions, constraints to follow, red flags to avoid, etc.
 
     validations:
       required: false
@@ -55,10 +36,7 @@ body:
     attributes:
       label: Updates and actions
       description: |
-        Provide updates as we start to plan and do work.
-        - Sub-issues and tasks to work on
-        - Links to project boards
-        - Updates over time
+        (optional) A place to track ongoing work items or tasks, as we figure them out.
 
     validations:
       required: false

--- a/.github/ISSUE_TEMPLATE/01_new-issue.yml
+++ b/.github/ISSUE_TEMPLATE/01_new-issue.yml
@@ -6,7 +6,8 @@ body:
     attributes:
       label: Context
       description: |
-        Any background information that helps others take understand this issue and why it is important.
+        Any background information that helps others understand this issue and why it is important.
+
     validations:
       required: true
 


### PR DESCRIPTION
I find it kind-of awkward to combine our "background and proposal" topics into a single section. It feels a bit wordy, and tends to result in intermingling the two.

This PR proposes separating them into two sections: one for "Context" and one for "Proposal". The goal here is to make the proposal really explicit and concise, and separate it from the "background information".