### PR TITLE
FIX: Fix line splitting in sphinx docs action

### DIFF
--- a/.github/workflows/documentation-link-check.yaml
+++ b/.github/workflows/documentation-link-check.yaml
@@ -77,12 +77,22 @@ jobs:
           # Parse each line for the file / line number and build GitHub links.
           out = ["### Link and reference warnings", ""]
           for iline in warnings.read_text().strip().split("\n"):
-              file_path, warning = iline.split(":")
-              # Remove the GitHub Action-specific path
-              file_path = file_path.replace(str(here), "").strip("/")
-              
+              parts = iline.split(":", 1)
+              if len(parts) == 2:
+                  file_path, warning = parts
+                  
+                  # Remove the GitHub Action-specific path
+                  file_path = file_path.replace(str(here), "").strip("/")
+              else:
+                  # If no colon, assume there's no file path, only a warning.
+                  file_path = None
+                  warning = parts[0]
+
+              # If there's no file_path just append the warning.
+              if not file_path:
+                out.append(f"**Warning**\n- {warning}\n")
               # If file_path has a line number, it points to an actual file
-              if len(file_path.rsplit(":")) == 2:
+              elif len(file_path.rsplit(":")) == 2:
                   file_path, lineno = file_path.rsplit(":")
                   url = f"https://github.com/{repo}/blob/main/{file_path}?plain=1#L{lineno}"
                   out.append(f"[**{file_path}#{lineno}**]({url})\n- {warning}\n")

--- a/.github/workflows/documentation-link-check.yaml
+++ b/.github/workflows/documentation-link-check.yaml
@@ -77,7 +77,7 @@ jobs:
           # Parse each line for the file / line number and build GitHub links.
           out = ["### Link and reference warnings", ""]
           for iline in warnings.read_text().strip().split("\n"):
-              file_path, warning = iline.split(": ", 1)
+              file_path, warning = iline.split(":")
               # Remove the GitHub Action-specific path
               file_path = file_path.replace(str(here), "").strip("/")
               


### PR DESCRIPTION
This line was causing the following error in the infrastructure repo (https://github.com/2i2c-org/infrastructure/runs/7965379841?check_suite_focus=true):

```python
Traceback (most recent call last):
  File "/home/runner/work/_temp/bacb2119-4fa4-[42](https://github.com/2i2c-org/infrastructure/runs/7965379841?check_suite_focus=true#step:6:43)8f-9cee-efcb812bfe84.py", line 20, in <module>
    file_path, warning = iline.split(": ", 1)
ValueError: not enough values to unpack (expected 2, got 1)
Error: Process completed with exit code 1.
```

I'm not sure I've got the fix right because I don't have enough context of what Sphinx messages look like, but I tried! :)