### PR TITLE
Add labels sync workflow

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -1,0 +1,88 @@
+# Functional Area
+- name: "Administration"
+  color: "C5DEF5"
+  aliases: []
+  description: "General actions needed in the organization and interfacing with CS&S."
+
+- name: "Community"
+  color: "C5DEF5"
+  aliases: []
+  description: "Engaging and cultivating communities that we currently serve."
+
+- name: "Engineering:Cloud Ops"
+  color: "C5DEF5"
+  aliases: ["Engineering"]
+  description: "Operational and cloud infrastructure efforts."
+
+- name: "Engineering:Development"
+  color: "C5DEF5"
+  aliases: []
+  description: "Development-focused efforts for engineering team."
+
+- name: "Finance"
+  color: "C5DEF5"
+  aliases: []
+  description: "Accounting and financial information."
+
+- name: "Human Resources"
+  color: "C5DEF5"
+  aliases: []
+  description: "Policies and issues related to people and roles."
+
+- name: "Operations"
+  color: "C5DEF5"
+  aliases: []
+  description: "Planning and coordination practices for our teams."
+
+- name: "Organization"
+  color: "C5DEF5"
+  aliases: []
+  description: "Issues that span the entire 2i2c organization."
+
+- name: "Outreach"
+  color: "C5DEF5"
+  aliases: []
+  description: "Communications from 2i2c to the outside world in general."
+
+- name: "Partnerships"
+  color: "C5DEF5"
+  aliases: []
+  description: "Creating and fostering new collaborations with external groups"
+
+- name: "Product"
+  color: "C5DEF5"
+  aliases: []
+  description: "User-facing features, behavior, UX, etc"
+
+
+# Issue type
+- name: "Bug"
+  color: "1D76DB"
+  aliases: ["bug"]
+  description: "Something isn't working or behaves unexpectedly."
+
+- name: "Discussion"
+  color: "1D76DB"
+  aliases: []
+  description: "A discussion that may not have a specific action at the end."
+
+- name: "Documentation"
+  color: "1D76DB"
+  aliases: []
+  description: "A change to our documentation."
+
+- name: "Enhancement"
+  color: "1D76DB"
+  aliases: []
+  description: "Making an improvement to something or creating something new."
+
+- name: "Meeting:Team Sync"
+  color: "1D76DB"
+  aliases: [":label: meeting:sprint-planning"]
+  description: "Our bi-weekly team sync meetings."
+
+- name: "Task"
+  color: "1D76DB"
+  aliases: []
+  description: "One or more actions to take."
+

--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -9,10 +9,10 @@
   aliases: []
   description: "Engaging and cultivating communities that we currently serve."
 
-- name: "Engineering:Cloud Ops"
+- name: "Engineering:SRE"
   color: "C5DEF5"
   aliases: ["Engineering"]
-  description: "Operational and cloud infrastructure efforts."
+  description: "Cloud infrastructure operations and development."
 
 - name: "Engineering:Development"
   color: "C5DEF5"
@@ -27,7 +27,7 @@
 - name: "Human Resources"
   color: "C5DEF5"
   aliases: []
-  description: "Policies and issues related to people and roles."
+  description: "People and roles at 2i2c."
 
 - name: "Operations"
   color: "C5DEF5"
@@ -37,12 +37,12 @@
 - name: "Organization"
   color: "C5DEF5"
   aliases: []
-  description: "Issues that span the entire 2i2c organization."
+  description: "Spans the entire 2i2c organization."
 
 - name: "Outreach"
   color: "C5DEF5"
   aliases: []
-  description: "Communications from 2i2c to the outside world in general."
+  description: "External communications and presentations."
 
 - name: "Partnerships"
   color: "C5DEF5"
@@ -64,7 +64,7 @@
 - name: "Discussion"
   color: "1D76DB"
   aliases: []
-  description: "A discussion that may not have a specific action at the end."
+  description: "A discussion without a specific action to take."
 
 - name: "Documentation"
   color: "1D76DB"
@@ -74,15 +74,15 @@
 - name: "Enhancement"
   color: "1D76DB"
   aliases: []
-  description: "Making an improvement to something or creating something new."
+  description: "An improvement to something or creating something new."
 
 - name: "Meeting:Team Sync"
   color: "1D76DB"
   aliases: [":label: meeting:sprint-planning"]
-  description: "Our bi-weekly team sync meetings."
+  description: "Bi-weekly team sync meetings."
 
 - name: "Task"
   color: "1D76DB"
   aliases: []
-  description: "One or more actions to take."
+  description: "Actions that don't involve changing our code or docs."
 

--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -1,0 +1,52 @@
+# Synchronize Issue Labels from here to several repositories.
+# Labels are defined in .github/labels.yml
+#
+# Summary:
+# Uses a personal access token for @choldgraf with write permissions to 2i2c repositories
+# 
+# ref: https://github.com/Financial-Times/github-label-sync#label-config-file
+
+name: "Sync Issue Labels"
+on:
+  # NOTE: github.event is workflow_dispatch payload:
+  # https://docs.github.com/en/developers/webhooks-and-events/webhooks/webhook-events-and-payloads#workflow_dispatch
+  workflow_dispatch:
+    inputs:
+      dryrun:
+        description: "dryrun: Preview changes to labels without editing them (true|false)"
+        required: true
+        type: boolean
+        default: true
+
+jobs:
+  sync:
+    strategy:
+      matrix:
+        repository: ["docs", "infrastructure", "meta", "team-compass"]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@master
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 16
+      # Install github-label-sync
+      - run: npm install -g github-label-sync
+      
+      # Decide whether to use the dryrun flag or not
+      - name: Set dryrun flag
+        run: |
+          if ${{ github.event.inputs.dryrun }} == 'true'; then
+              echo "DRYRUN=-d" >> "$GITHUB_ENV"
+          else
+              echo "DRYRUN=" >> "$GITHUB_ENV"
+          fi
+
+      # Run the label sync on each repository in our organization
+      - run: >
+          github-label-sync
+            $DRYRUN
+            -a ${{ secrets.ACCESS_TOKEN }}
+            -A
+            -l ../labels.yml
+            ${{ matrix.repository }}

--- a/README.md
+++ b/README.md
@@ -2,11 +2,26 @@
 
 This is a meta repository that defines some shared files that our other repositories inherit.
 
-## Files used in this repository
+Below is a list of major files / functionality in this repository.
 
-Below is a quick list of these files:
+## `.github/ISSUE_TEMPLATE/` sync issue templates
 
-- `.github/ISSUE_TEMPLATE/`: Issue templates for other repositories. When these files changed, they are automatically synced to our other repositories via [this GitHub action](.github/workflows/sync-issue-templates.yaml). See the comments in those actions for more details.
+Issue templates for other repositories. When these files changed, they are automatically synced to our other repositories.
+
+- Syncing is done via [`.github/workflows/sync-issue-templates.yaml`](.github/workflows/sync-issue-templates.yaml).
+- The issue templates are defined in [`.github/sync.yml`](.github/sync.yml).
+
+## `.github/labels.yml` sync issue labels
+
+We automatically synchronize a subset of issue labels across all of our major repositories.
+This is done via a [**workflow_dispatch**](https://github.blog/changelog/2021-11-10-github-actions-input-types-for-manual-workflows/).
+
+- The repositores and action is defined in [`.github/workflows/sync-labels.yml`](.github/workflows/sync-labels.yml).
+- The labels are defined in [`.github/labels.yml`](.github/labels.yml).
+
+## Reusable Workflow - Documentation link checks
+
+We define a re-usable GitHub workflow to use Sphinx's `linkcheck` builder and open an issue if there are broken links. It is defined at [`.github/workflows/documentation-link-check.yaml`](.github/workflows/documentation-link-check.yaml).
 
 ## Pre-commit hooks
 


### PR DESCRIPTION
This adds a short GitHub Workflow that uses a `workflow_dispatch` and [this label sync tool](https://github.com/Financial-Times/github-label-sync) to synchronize a subset of labels across our major repositories. Right now I'm doing this on a subset of repos that are defined in the workflow.

- ref: https://github.com/2i2c-org/team-compass/issues/484
- Once we merge this and I successfully run it, I'll close that issue.