### PR TITLE
Add `in:title` to search query for our linkcheck action

### DIFF
--- a/.github/workflows/documentation-link-check.yaml
+++ b/.github/workflows/documentation-link-check.yaml
@@ -109,7 +109,7 @@ jobs:
       # If it does, we will update that issue.
       - name: Check for an open issue
         run: |
-          ISSUE_NUMBER=$( gh issue list --search "${{ inputs.issue_title }}" | awk '{print $1}' )
+          ISSUE_NUMBER=$( gh issue list --search "in:title ${{ inputs.issue_title }}" | awk '{print $1}' )
           echo "ISSUE_NUMBER=$ISSUE_NUMBER" >> $GITHUB_ENV
 
       # Use the warnings.txt content to populate a new issue.


### PR DESCRIPTION
Our search query was searching both the title and body of some issues, and thus was accidentally returning a *list* of issues instead of just the one broken links issue. This restricts the search to only the title.