### PR TITLE
Update github actions versions

### DIFF
--- a/.github/workflows/documentation-link-check.yaml
+++ b/.github/workflows/documentation-link-check.yaml
@@ -36,8 +36,8 @@ jobs:
   check-links:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
         with:
           python-version: "3.9"
           cache: "pip"
@@ -117,7 +117,7 @@ jobs:
       # otherwise a pre-existing issue will be updated.
       - name: Create issue from errors output
         if: steps.buildDocs.outcome == 'failure'
-        uses: peter-evans/create-issue-from-file@v4.0.0
+        uses: peter-evans/create-issue-from-file@v4
         with:
           issue-number: ${{ env.ISSUE_NUMBER }}
           title: ${{ inputs.issue_title }}

--- a/.github/workflows/sync-issue-templates.yaml
+++ b/.github/workflows/sync-issue-templates.yaml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@master
+        uses: actions/checkout@v3
       - name: Run GitHub File Sync
         uses: BetaHuhn/repo-file-sync-action@v1
         with:

--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@master
+        uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
           node-version: 16


### PR DESCRIPTION
We still had the node12 -> 16 warning for the workflows defined here, which were referenced from 2i2c-org/infrastructure.