### PR TITLE
Add proto-goal issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/goal-proposal.yml
+++ b/.github/ISSUE_TEMPLATE/goal-proposal.yml
@@ -1,4 +1,4 @@
-name: 💡 Goal Proposal
+name: 🎯 Goal Proposal
 description: A template for a goal proposal that is ready to be discussed and prioritized. Goals sprint board https://github.com/orgs/2i2c-org/projects/44.
 title: "[Proto-goal]: "
 labels: ["proto-goal"]

--- a/.github/ISSUE_TEMPLATE/goal-proposal.yml
+++ b/.github/ISSUE_TEMPLATE/goal-proposal.yml
@@ -1,0 +1,45 @@
+name: 💡 Goal Proposal
+description: A template for a goal proposal that is ready to be discussed and prioritized. Goals sprint board https://github.com/orgs/2i2c-org/projects/44.
+title: "[Proto-goal]: "
+labels: ["proto-goal"]
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: Brief description
+      description: |
+        Short description of the goal proposed.
+        Tips:
+        - focus on outcomes
+        - scope it to not be more than 2 months
+        - try not to list actions
+        - have interested team members
+    validations:
+      required: false
+
+  - type: textarea
+    id: rationale
+    attributes:
+      label: Rationale and value to our mission
+      description: |
+        Outcomes must be based on value that we've provided to our partner communities.
+        They should meet community needs, allow us to deliver a better service, or further a critical aspect of our mission. 
+    validations:
+      required: false
+
+  - type: textarea
+    id: success
+    attributes:
+      label: Definition of completion and success
+      description: |
+        Outcomes need to be measurable for us to know whether we have achieved them or not.
+        Define a metric of success (quantitative or qualitative) that we can measure to decide if our goal has been accomplished.
+    validations:
+      required: false
+
+  - type: References and links to issues
+    id: success
+    attributes:
+      label: Definition of completion and success
+      description: |
+        (optional) A place to track ongoing work items or tasks, as we figure them out.

--- a/.github/ISSUE_TEMPLATE/goal-proposal.yml
+++ b/.github/ISSUE_TEMPLATE/goal-proposal.yml
@@ -37,9 +37,11 @@ body:
     validations:
       required: false
 
-  - type: References and links to issues
-    id: success
+  - type: textarea
+    id: references
     attributes:
-      label: Definition of completion and success
+      label: References and links to issues
       description: |
-        (optional) A place to track ongoing work items or tasks, as we figure them out.
+        Any links or references to issues relevant to this goal proposal.
+    validations:
+      required: false


### PR DESCRIPTION
Since I was not aware of any constraints related to which repository goal proposal issues should be opened, I figured to add an issue template according to the structure proposed in https://docs.google.com/document/d/1EukvDeBk1JUiWQl30tFwhmXbY_It8RZhGAAS0NlhA2Q/edit?usp=sharing in this org wide space.

This will allow us to have access to the template from all the 2i2c repositories.

P.S. I'm aware that the structure was just a proposal, and this is why, none of the fields are mandatory. It's supposed to be seen as a starting point to evaluate how the current proposal feels like and modify it where we consider appropriate, without digging it from the gdoc.

Related:
- https://github.com/2i2c-org/meta/issues/596
- https://github.com/2i2c-org/team-compass/issues/695

Template rendered [here](https://github.com/GeorgianaElena/.github-2i2c/issues/new?assignees=&labels=proto-goal&projects=&template=goal-proposal.yml&title=%5BProto-goal%5D%3A+)